### PR TITLE
fix an issue when 'sys.stdout' is none (#141)

### DIFF
--- a/wsgidav/wsgidav_app.py
+++ b/wsgidav/wsgidav_app.py
@@ -497,7 +497,8 @@ class WsgiDAVApp(object):
                         time=util.get_log_time(),
                         method=environ.get("REQUEST_METHOD"),
                         path=safe_re_encode(
-                            environ.get("PATH_INFO", ""), sys.stdout.encoding
+                            environ.get("PATH_INFO", ""),
+                            sys.stdout.encoding if sys.stdout.encoding else "utf-8",
                         ),
                         extra=extra,
                         status=status,


### PR DESCRIPTION
* fix an issue when 'sys.stdout' is none

When we use pythonw.exe(the python interpreter without GUI on windows),  sys.stdout will be set to none. That will cause an AttributeError which blocking all wsgidav services.

* tox -e black